### PR TITLE
Task 2: social account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/social-account/contracts/SocialAccount.sol
+++ b/social-account/contracts/SocialAccount.sol
@@ -1,8 +1,16 @@
 pragma solidity ^0.4.21;
 
+import "./SocialConnection.sol";
+
 contract SocialAccount {
     string public name;
     address public owner;
+
+    // Stores following connections:
+    // 1. Initiated by me (owns such connections)
+    // 2. Accepted by me
+    // 3. Cancelled
+    mapping(address => SocialConnection) public connections;
 
     constructor(string _name) public {
         name = _name;
@@ -12,5 +20,53 @@ contract SocialAccount {
     function setName(string _name) public {
         require(msg.sender == owner);
         name = _name;
+    }
+
+    // `connection` is zero if we want to create a new `SocialConnection`
+    // and non-zero otherwise. This prevents frontrunning: user always knows
+    // what `SocialConnection` they accept and can check its code.
+    function addFriend(SocialAccount other, SocialConnection connection) public {
+        require(msg.sender == owner);
+        checkFriendRemoved(other);
+        require(connections[other] == SocialConnection(0));
+        if (connection == SocialConnection(0)) {
+            connections[other] = new SocialConnection(other);
+        } else {
+            // Ensure that the connection still exists and double-check.
+            require(connection.initiator() == other);
+            require(connection.acceptor() == this);
+            connections[other] = connection;
+            connection.accept();
+        }
+    }
+
+    // Unsafe as it doesn't check type of the proposed `SocialConnection`.
+    // It may be unknown in advance because of either malicious `SocialAccount`
+    // on the other end or frontrunning.
+    function addFriendWithAnyConnection(SocialAccount other) external {
+        addFriend(other, other.connections(this));
+    }
+
+    function checkFriendRemoved(SocialAccount other) public {
+        if (connections[other] != SocialConnection(0) && connections[other].status() == SocialConnection.Status.CANCELLED) {
+            delete connections[other];
+        }
+    }
+
+    function removeFriend(SocialAccount other) external {
+        require(msg.sender == owner);
+        SocialConnection conn = connections[other];
+        if (conn == SocialConnection(0)) {
+            return;
+        }
+        conn.cancel();  // We assume that SocialConnection is safe.
+        delete connections[other];
+
+        // Notify the other contract about friend removal, try to "safe push".
+        // This contract's `checkFriendRemoved`'s gas consumption is slightly
+        // below 8600, so there is some a margin.
+        if (!address(other).call.gas(10000)(bytes4(keccak256("checkFriendRemoved(address)")), this)) {
+          // It's more of a nice gesture than a necessity, so ignore all errors.
+        }
     }
 }

--- a/social-account/contracts/SocialAccount.sol
+++ b/social-account/contracts/SocialAccount.sol
@@ -1,4 +1,16 @@
 pragma solidity ^0.4.21;
 
 contract SocialAccount {
+    string public name;
+    address public owner;
+
+    constructor(string _name) public {
+        name = _name;
+        owner = msg.sender;
+    }
+
+    function setName(string _name) public {
+        require(msg.sender == owner);
+        name = _name;
+    }
 }

--- a/social-account/contracts/SocialAccount.sol
+++ b/social-account/contracts/SocialAccount.sol
@@ -6,6 +6,8 @@ contract SocialAccount {
     string public name;
     address public owner;
 
+    event NameChanged(SocialAccount indexed account, string oldName, string newName);
+
     // Stores following connections:
     // 1. Initiated by me (owns such connections)
     // 2. Accepted by me
@@ -19,6 +21,7 @@ contract SocialAccount {
 
     function setName(string _name) public {
         require(msg.sender == owner);
+        emit NameChanged(this, name, _name);
         name = _name;
     }
 

--- a/social-account/contracts/SocialAccount.sol
+++ b/social-account/contracts/SocialAccount.sol
@@ -1,0 +1,4 @@
+pragma solidity ^0.4.21;
+
+contract SocialAccount {
+}

--- a/social-account/contracts/SocialAccount.sol
+++ b/social-account/contracts/SocialAccount.sol
@@ -30,11 +30,8 @@ contract SocialAccount {
     // what `SocialConnection` they accept and can check its code.
     function addFriend(SocialAccount other, SocialConnection connection) public {
         require(msg.sender == owner);
-        if (connections[other] != SocialConnection(0) && connections[other].status() == SocialConnection.Status.CANCELLED) {
-            delete connections[other];
-        }
         // There is neither pending request, nor accepted request.
-        require(connections[other] == SocialConnection(0));
+        require(getFriendConnection(other) == SocialConnection(0));
         if (connection == SocialConnection(0)) {
             connections[other] = new SocialConnection(other);
         } else {
@@ -44,6 +41,13 @@ contract SocialAccount {
             connections[other] = connection;
             connection.accept();
         }
+    }
+
+    function getFriendConnection(SocialAccount other) internal returns (SocialConnection) {
+        if (connections[other] != SocialConnection(0) && connections[other].status() == SocialConnection.Status.CANCELLED) {
+            delete connections[other];
+        }
+        return connections[other];
     }
 
     // Unsafe as it doesn't check type of the proposed `SocialConnection`.

--- a/social-account/contracts/SocialConnection.sol
+++ b/social-account/contracts/SocialConnection.sol
@@ -3,20 +3,23 @@ pragma solidity ^0.4.21;
 import "./SocialAccount.sol";
 
 contract SocialConnection {
+    enum Status { PROPOSED, ACCEPTED, CANCELLED }
+
     SocialAccount public initiator;
     SocialAccount public acceptor;
-    bool public accepted;
+    Status public status;
 
     constructor(SocialAccount _acceptor) public {
         require(msg.sender != address(_acceptor));
         initiator = SocialAccount(msg.sender);
         acceptor = _acceptor;
-        accepted = false;
+        status = Status.PROPOSED;
     }
 
     function accept() public {
         require(msg.sender == address(acceptor));
-        accepted = true;
+        require(status <= Status.ACCEPTED);
+        status = Status.ACCEPTED;
     }
 
     function cancel() public {
@@ -24,6 +27,6 @@ contract SocialConnection {
         // Do not notify either contract because external call may fail, thus
         // blocking friendship cancellation, which is no good.
         // "Favor pull over push".
-        selfdestruct(msg.sender);
+        status = Status.CANCELLED;
     }
 }

--- a/social-account/contracts/SocialConnection.sol
+++ b/social-account/contracts/SocialConnection.sol
@@ -5,6 +5,8 @@ import "./SocialAccount.sol";
 contract SocialConnection {
     enum Status { PROPOSED, ACCEPTED, CANCELLED }
 
+    event StatusUpdated(SocialConnection indexed connection, SocialAccount indexed from, SocialAccount indexed to, Status oldStatus, Status newStatus);
+
     SocialAccount public initiator;
     SocialAccount public acceptor;
     Status public status;
@@ -14,12 +16,13 @@ contract SocialConnection {
         initiator = SocialAccount(msg.sender);
         acceptor = _acceptor;
         status = Status.PROPOSED;
+        emit StatusUpdated(this, initiator, acceptor, status, status);
     }
 
     function accept() public {
         require(msg.sender == address(acceptor));
         require(status <= Status.ACCEPTED);
-        status = Status.ACCEPTED;
+        changeStatus(Status.ACCEPTED);
     }
 
     function cancel() public {
@@ -27,6 +30,14 @@ contract SocialConnection {
         // Do not notify either contract because external call may fail, thus
         // blocking friendship cancellation, which is no good.
         // "Favor pull over push".
-        status = Status.CANCELLED;
+        changeStatus(Status.CANCELLED);
+    }
+
+    function changeStatus(Status newStatus) private {
+        if (status == newStatus) {
+            return;
+        }
+        emit StatusUpdated(this, initiator, acceptor, status, newStatus);
+        status = newStatus;
     }
 }

--- a/social-account/contracts/SocialConnection.sol
+++ b/social-account/contracts/SocialConnection.sol
@@ -7,21 +7,23 @@ contract SocialConnection {
     SocialAccount public acceptor;
     bool public accepted;
 
-    constructor(SocialAccount _initiator, SocialAccount _acceptor) public {
-        require(msg.sender == _initiator.owner());
-        require(_initiator != _acceptor);
-        initiator = _initiator;
+    constructor(SocialAccount _acceptor) public {
+        require(msg.sender != address(_acceptor));
+        initiator = SocialAccount(msg.sender);
         acceptor = _acceptor;
         accepted = false;
     }
 
     function accept() public {
-        require(msg.sender == acceptor.owner());
+        require(msg.sender == address(acceptor));
         accepted = true;
     }
 
     function cancel() public {
-        require(msg.sender == initiator.owner() || msg.sender == acceptor.owner());
+        require(msg.sender == address(initiator) || msg.sender == address(acceptor));
+        // Do not notify either contract because external call may fail, thus
+        // blocking friendship cancellation, which is no good.
+        // "Favor pull over push".
         selfdestruct(msg.sender);
     }
 }

--- a/social-account/contracts/SocialConnection.sol
+++ b/social-account/contracts/SocialConnection.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.4.21;
+
+import "./SocialAccount.sol";
+
+contract SocialConnection {
+    SocialAccount public initiator;
+    SocialAccount public acceptor;
+    bool public accepted;
+
+    constructor(SocialAccount _initiator, SocialAccount _acceptor) public {
+        require(msg.sender == _initiator.owner());
+        require(_initiator != _acceptor);
+        initiator = _initiator;
+        acceptor = _acceptor;
+        accepted = false;
+    }
+
+    function accept() public {
+        require(msg.sender == acceptor.owner());
+        accepted = true;
+    }
+
+    function cancel() public {
+        require(msg.sender == initiator.owner() || msg.sender == acceptor.owner());
+        selfdestruct(msg.sender);
+    }
+}

--- a/social-account/package-lock.json
+++ b/social-account/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "social-account",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "truffle-test-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/truffle-test-utils/-/truffle-test-utils-0.1.0.tgz",
+      "integrity": "sha512-evkghw7lPf3lTDXbhLaIeWUEy+Zx/1txeP2lywnogX1C2LmQkt9MGyFlitr5a5sF8skJE60Z0hZYREuLTdKtsg==",
+      "dev": true,
+      "requires": {
+        "chai": "4.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    }
+  }
+}

--- a/social-account/package.json
+++ b/social-account/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "social-account",
+  "version": "1.0.0",
+  "description": "",
+  "main": "truffle-config.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "truffle-test-utils": "^0.1.0"
+  }
+}

--- a/social-account/test/test_social_account.js
+++ b/social-account/test/test_social_account.js
@@ -1,0 +1,43 @@
+var SocialAccount = artifacts.require("SocialAccount");
+
+contract("SocialAccount", async (accounts) => {
+  it("should initialize correctly", async () => {
+    let acc = await SocialAccount.new("My Name");
+    assert.equal(await acc.owner.call(), accounts[0]);
+    assert.equal(await acc.name.call(), "My Name");
+  });
+
+  it("allow name changes by owner", async () => {
+    let acc = await SocialAccount.new("My Name");
+    await acc.setName("Other Name", {from: accounts[0]});
+    assert.equal(await acc.name.call(), "Other Name");
+  });
+
+  it("prohibits name changes by others", async () => {
+    let acc = await SocialAccount.new("My Name");
+    await expectThrow(acc.setName("Other Name", {from: accounts[1]}));
+  });
+});
+
+// https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/test/helpers/expectThrow.js
+let expectThrow = async promise => {
+  try {
+    await promise;
+  } catch (error) {
+    // TODO: Check jump destination to destinguish between a throw
+    //       and an actual invalid jump.
+    const invalidOpcode = error.message.search('invalid opcode') >= 0;
+    // TODO: When we contract A calls contract B, and B throws, instead
+    //       of an 'invalid jump', we get an 'out of gas' error. How do
+    //       we distinguish this from an actual out of gas event? (The
+    //       ganache log actually show an 'invalid jump' event.)
+    const outOfGas = error.message.search('out of gas') >= 0;
+    const revert = error.message.search('revert') >= 0;
+    assert(
+      invalidOpcode || outOfGas || revert,
+      'Expected throw, got \'' + error + '\' instead',
+    );
+    return;
+  }
+  assert.fail('Expected throw not received');
+};

--- a/social-account/test/test_social_account.js
+++ b/social-account/test/test_social_account.js
@@ -1,3 +1,4 @@
+require("truffle-test-utils").init();
 var SocialAccount = artifacts.require("SocialAccount");
 var SocialConnection = artifacts.require("SocialConnection");
 
@@ -19,8 +20,16 @@ contract("SocialAccount", async (accounts) => {
 
   it("allow name changes by owner", async () => {
     let acc = await SocialAccount.new("My Name");
-    await acc.setName("Other Name", {from: accounts[0]});
+    let res = await acc.setName("Other Name", {from: accounts[0]});
     assert.equal(await acc.name.call(), "Other Name");
+    assert.web3Event(res, {
+      event: 'NameChanged',
+      args: {
+        account: acc.address,
+        oldName: "My Name",
+        newName: "Other Name"
+      },
+    });
   });
 
   it("prohibits name changes by others", async () => {

--- a/social-account/test/test_social_account.js
+++ b/social-account/test/test_social_account.js
@@ -1,4 +1,14 @@
 var SocialAccount = artifacts.require("SocialAccount");
+var SocialConnection = artifacts.require("SocialConnection");
+
+const PROPOSED = 0;
+const ACCEPTED = 1;
+const CANCELLED = 2;
+
+const ZERO_ADDRESS = "0x" + "0".repeat(40);
+
+const ACCEPTOR = "acceptor";
+const INITIATOR = "initiator";
 
 contract("SocialAccount", async (accounts) => {
   it("should initialize correctly", async () => {
@@ -16,6 +26,53 @@ contract("SocialAccount", async (accounts) => {
   it("prohibits name changes by others", async () => {
     let acc = await SocialAccount.new("My Name");
     await expectThrow(acc.setName("Other Name", {from: accounts[1]}));
+  });
+
+  it("befriends other accounts", async() => {
+    let acc1 = await SocialAccount.new("Name1");
+    let acc2 = await SocialAccount.new("Name2");
+    await acc1.addFriendWithAnyConnection(acc2.address);
+
+    let conn = SocialConnection.at(await acc1.connections(acc2.address));
+    assert.equal(await conn.initiator(), acc1.address);
+    assert.equal(await conn.acceptor(), acc2.address);
+    assert.equal(await conn.status(), PROPOSED);
+
+    await acc2.addFriendWithAnyConnection(acc1.address);
+    assert.equal(await conn.status(), ACCEPTED);
+    assert.equal(await acc2.connections(acc1.address), conn.address);
+  });
+
+  [ACCEPTOR, INITIATOR].forEach(param => {
+    it("befriends after acceptance and " + param + " cancels", async () => {
+      let acc1 = await SocialAccount.new("Name1");
+      let acc2 = await SocialAccount.new("Name2");
+      await acc1.addFriendWithAnyConnection(acc2.address);
+      let conn = SocialConnection.at(await acc1.connections(acc2.address));
+      await acc2.addFriendWithAnyConnection(acc1.address);
+
+      if (param == INITIATOR) {
+        await acc1.removeFriend(acc2.address);
+      } else if (param == ACCEPTOR) {
+        await acc2.removeFriend(acc1.address);
+      } else {
+        assert.isTrue(false);
+      }
+
+      assert.equal(await conn.status(), CANCELLED);
+      assert.equal(await acc1.connections(acc2.address), ZERO_ADDRESS);
+      assert.equal(await acc2.connections(acc1.address), ZERO_ADDRESS);
+
+      await acc1.addFriendWithAnyConnection(acc2.address);
+      let conn2 = SocialConnection.at(await acc1.connections(acc2.address));
+      assert.equal(await conn2.status(), PROPOSED);
+
+      await acc2.addFriendWithAnyConnection(acc1.address);
+      assert.equal(await conn2.status(), ACCEPTED);
+      assert.equal(await acc1.connections(acc2.address), conn2.address);
+      assert.equal(await acc2.connections(acc1.address), conn2.address);
+      assert.equal(await conn.status(), CANCELLED);
+    });
   });
 });
 

--- a/social-account/test/test_social_account.js
+++ b/social-account/test/test_social_account.js
@@ -60,8 +60,8 @@ contract("SocialAccount", async (accounts) => {
       }
 
       assert.equal(await conn.status(), CANCELLED);
-      assert.equal(await acc1.connections(acc2.address), ZERO_ADDRESS);
-      assert.equal(await acc2.connections(acc1.address), ZERO_ADDRESS);
+      assert.oneOf(await acc1.connections(acc2.address), [ZERO_ADDRESS, conn.address]);
+      assert.oneOf(await acc2.connections(acc1.address), [ZERO_ADDRESS, conn.address]);
 
       await acc1.addFriendWithAnyConnection(acc2.address);
       let conn2 = SocialConnection.at(await acc1.connections(acc2.address));

--- a/social-account/test/test_social_account.js
+++ b/social-account/test/test_social_account.js
@@ -42,14 +42,14 @@ contract("SocialAccount", async (accounts) => {
     let acc2 = await SocialAccount.new("Name2");
     await acc1.addFriendWithAnyConnection(acc2.address);
 
-    let conn = SocialConnection.at(await acc1.connections(acc2.address));
-    assert.equal(await conn.initiator(), acc1.address);
-    assert.equal(await conn.acceptor(), acc2.address);
-    assert.equal(await conn.status(), PROPOSED);
+    let conn = SocialConnection.at(await acc1.connections.call(acc2.address));
+    assert.equal(await conn.initiator.call(), acc1.address);
+    assert.equal(await conn.acceptor.call(), acc2.address);
+    assert.equal(await conn.status.call(), PROPOSED);
 
     await acc2.addFriendWithAnyConnection(acc1.address);
-    assert.equal(await conn.status(), ACCEPTED);
-    assert.equal(await acc2.connections(acc1.address), conn.address);
+    assert.equal(await conn.status.call(), ACCEPTED);
+    assert.equal(await acc2.connections.call(acc1.address), conn.address);
   });
 
   [ACCEPTOR, INITIATOR].forEach(param => {
@@ -57,7 +57,7 @@ contract("SocialAccount", async (accounts) => {
       let acc1 = await SocialAccount.new("Name1");
       let acc2 = await SocialAccount.new("Name2");
       await acc1.addFriendWithAnyConnection(acc2.address);
-      let conn = SocialConnection.at(await acc1.connections(acc2.address));
+      let conn = SocialConnection.at(await acc1.connections.call(acc2.address));
       await acc2.addFriendWithAnyConnection(acc1.address);
 
       if (param == INITIATOR) {
@@ -68,19 +68,19 @@ contract("SocialAccount", async (accounts) => {
         assert.isTrue(false);
       }
 
-      assert.equal(await conn.status(), CANCELLED);
-      assert.oneOf(await acc1.connections(acc2.address), [ZERO_ADDRESS, conn.address]);
-      assert.oneOf(await acc2.connections(acc1.address), [ZERO_ADDRESS, conn.address]);
+      assert.equal(await conn.status.call(), CANCELLED);
+      assert.oneOf(await acc1.connections.call(acc2.address), [ZERO_ADDRESS, conn.address]);
+      assert.oneOf(await acc2.connections.call(acc1.address), [ZERO_ADDRESS, conn.address]);
 
       await acc1.addFriendWithAnyConnection(acc2.address);
-      let conn2 = SocialConnection.at(await acc1.connections(acc2.address));
-      assert.equal(await conn2.status(), PROPOSED);
+      let conn2 = SocialConnection.at(await acc1.connections.call(acc2.address));
+      assert.equal(await conn2.status.call(), PROPOSED);
 
       await acc2.addFriendWithAnyConnection(acc1.address);
-      assert.equal(await conn2.status(), ACCEPTED);
-      assert.equal(await acc1.connections(acc2.address), conn2.address);
-      assert.equal(await acc2.connections(acc1.address), conn2.address);
-      assert.equal(await conn.status(), CANCELLED);
+      assert.equal(await conn2.status.call(), ACCEPTED);
+      assert.equal(await acc1.connections.call(acc2.address), conn2.address);
+      assert.equal(await acc2.connections.call(acc1.address), conn2.address);
+      assert.equal(await conn.status.call(), CANCELLED);
     });
   });
 });

--- a/social-account/test/test_social_connection.js
+++ b/social-account/test/test_social_connection.js
@@ -1,0 +1,58 @@
+var SocialAccount = artifacts.require("SocialAccount");
+var SocialConnection = artifacts.require("SocialConnection");
+
+contract("SocialConnection", async (accounts) => {
+  beforeEach(async () => {
+    this.acc1 = (await SocialAccount.new("First", {from: accounts[1]})).address;
+    this.acc2 = (await SocialAccount.new("Second", {from: accounts[2]})).address;
+  });
+
+  it("should initialize correctly", async () => {
+    let conn = await SocialConnection.new(this.acc1, this.acc2, {from: accounts[1]});
+    assert.equal(await conn.initiator.call(), this.acc1);
+    assert.equal(await conn.acceptor.call(), this.acc2);
+    assert.equal(await conn.accepted.call(), false);
+  });
+
+  it("can be accepted", async () => {
+    let conn = await SocialConnection.new(this.acc1, this.acc2, {from: accounts[1]});
+    await conn.accept({from: accounts[2]});
+    assert.equal(await conn.initiator.call(), this.acc1);
+    assert.equal(await conn.acceptor.call(), this.acc2);
+    assert.equal(await conn.accepted.call(), true);
+  });
+
+  it("cannot be accepted by other person", async () => {
+    let conn = await SocialConnection.new(this.acc1, this.acc2, {from: accounts[1]});
+    await expectThrow(conn.accept({from: accounts[0]}));
+    await expectThrow(conn.accept({from: accounts[1]}));
+  });
+
+  it("cannot be created by other person", async () => {
+    await expectThrow(SocialConnection.new(this.acc1, this.acc2, {from: accounts[0]}));
+    await expectThrow(SocialConnection.new(this.acc1, this.acc2, {from: accounts[2]}));
+  });
+});
+
+// https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/test/helpers/expectThrow.js
+let expectThrow = async promise => {
+  try {
+    await promise;
+  } catch (error) {
+    // TODO: Check jump destination to destinguish between a throw
+    //       and an actual invalid jump.
+    const invalidOpcode = error.message.search('invalid opcode') >= 0;
+    // TODO: When we contract A calls contract B, and B throws, instead
+    //       of an 'invalid jump', we get an 'out of gas' error. How do
+    //       we distinguish this from an actual out of gas event? (The
+    //       ganache log actually show an 'invalid jump' event.)
+    const outOfGas = error.message.search('out of gas') >= 0;
+    const revert = error.message.search('revert') >= 0;
+    assert(
+      invalidOpcode || outOfGas || revert,
+      'Expected throw, got \'' + error + '\' instead',
+    );
+    return;
+  }
+  assert.fail('Expected throw not received');
+};

--- a/social-account/test/test_social_connection.js
+++ b/social-account/test/test_social_connection.js
@@ -16,10 +16,20 @@ contract("SocialConnection", async (accounts) => {
 
   it("can be accepted", async () => {
     let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
-    await conn.accept({from: accounts[2]});
+    let res = await conn.accept({from: accounts[2]});
     assert.equal(await conn.initiator.call(), accounts[1]);
     assert.equal(await conn.acceptor.call(), accounts[2]);
     assert.equal(await conn.status.call(), ACCEPTED);
+    assert.web3Event(res, {
+      event: 'StatusUpdated',
+      args: {
+        connection: conn.address,
+        from: accounts[1],
+        to: accounts[2],
+        oldStatus: PROPOSED,
+        newStatus: ACCEPTED
+      },
+    });  
   });
 
   it("cannot be accepted by other account", async () => {

--- a/social-account/test/test_social_connection.js
+++ b/social-account/test/test_social_connection.js
@@ -12,6 +12,24 @@ contract("SocialConnection", async (accounts) => {
     assert.equal(await conn.initiator.call(), accounts[1]);
     assert.equal(await conn.acceptor.call(), accounts[2]);
     assert.equal(await conn.status.call(), PROPOSED);
+
+    let logsPromise = new Promise(function(resolve, reject) {
+      let ev = conn.StatusUpdated({}, {fromBlock: 0, toBlock: 'latest'});
+      ev.get(function(error, logs) {
+        ev.stopWatching();
+        resolve(logs);
+      });
+    });
+    assert.web3Event({logs: await logsPromise}, {
+      event: 'StatusUpdated',
+      args: {
+        connection: conn.address,
+        from: accounts[1],
+        to: accounts[2],
+        oldStatus: PROPOSED,
+        newStatus: PROPOSED
+      },
+    });
   });
 
   it("can be accepted", async () => {

--- a/social-account/test/test_social_connection.js
+++ b/social-account/test/test_social_connection.js
@@ -2,35 +2,25 @@ var SocialAccount = artifacts.require("SocialAccount");
 var SocialConnection = artifacts.require("SocialConnection");
 
 contract("SocialConnection", async (accounts) => {
-  beforeEach(async () => {
-    this.acc1 = (await SocialAccount.new("First", {from: accounts[1]})).address;
-    this.acc2 = (await SocialAccount.new("Second", {from: accounts[2]})).address;
-  });
-
   it("should initialize correctly", async () => {
-    let conn = await SocialConnection.new(this.acc1, this.acc2, {from: accounts[1]});
-    assert.equal(await conn.initiator.call(), this.acc1);
-    assert.equal(await conn.acceptor.call(), this.acc2);
+    let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
+    assert.equal(await conn.initiator.call(), accounts[1]);
+    assert.equal(await conn.acceptor.call(), accounts[2]);
     assert.equal(await conn.accepted.call(), false);
   });
 
   it("can be accepted", async () => {
-    let conn = await SocialConnection.new(this.acc1, this.acc2, {from: accounts[1]});
+    let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
     await conn.accept({from: accounts[2]});
-    assert.equal(await conn.initiator.call(), this.acc1);
-    assert.equal(await conn.acceptor.call(), this.acc2);
+    assert.equal(await conn.initiator.call(), accounts[1]);
+    assert.equal(await conn.acceptor.call(), accounts[2]);
     assert.equal(await conn.accepted.call(), true);
   });
 
-  it("cannot be accepted by other person", async () => {
-    let conn = await SocialConnection.new(this.acc1, this.acc2, {from: accounts[1]});
+  it("cannot be accepted by other account", async () => {
+    let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
     await expectThrow(conn.accept({from: accounts[0]}));
     await expectThrow(conn.accept({from: accounts[1]}));
-  });
-
-  it("cannot be created by other person", async () => {
-    await expectThrow(SocialConnection.new(this.acc1, this.acc2, {from: accounts[0]}));
-    await expectThrow(SocialConnection.new(this.acc1, this.acc2, {from: accounts[2]}));
   });
 });
 

--- a/social-account/test/test_social_connection.js
+++ b/social-account/test/test_social_connection.js
@@ -1,12 +1,16 @@
 var SocialAccount = artifacts.require("SocialAccount");
 var SocialConnection = artifacts.require("SocialConnection");
 
+const PROPOSED = 0;
+const ACCEPTED = 1;
+const CANCELLED = 2;
+
 contract("SocialConnection", async (accounts) => {
   it("should initialize correctly", async () => {
     let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
     assert.equal(await conn.initiator.call(), accounts[1]);
     assert.equal(await conn.acceptor.call(), accounts[2]);
-    assert.equal(await conn.accepted.call(), false);
+    assert.equal(await conn.status.call(), PROPOSED);
   });
 
   it("can be accepted", async () => {
@@ -14,13 +18,14 @@ contract("SocialConnection", async (accounts) => {
     await conn.accept({from: accounts[2]});
     assert.equal(await conn.initiator.call(), accounts[1]);
     assert.equal(await conn.acceptor.call(), accounts[2]);
-    assert.equal(await conn.accepted.call(), true);
+    assert.equal(await conn.status.call(), ACCEPTED);
   });
 
   it("cannot be accepted by other account", async () => {
     let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
     await expectThrow(conn.accept({from: accounts[0]}));
     await expectThrow(conn.accept({from: accounts[1]}));
+    assert.equal(await conn.status.call(), PROPOSED);
   });
 });
 

--- a/social-account/test/test_social_connection.js
+++ b/social-account/test/test_social_connection.js
@@ -1,3 +1,4 @@
+require("truffle-test-utils").init();
 var SocialAccount = artifacts.require("SocialAccount");
 var SocialConnection = artifacts.require("SocialConnection");
 
@@ -30,14 +31,34 @@ contract("SocialConnection", async (accounts) => {
 
   it("can be cancelled by initiator before acceptance", async () => {
     let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
-    await conn.cancel({from: accounts[1]});
+    let res = await conn.cancel({from: accounts[1]});
     assert.equal(await conn.status.call(), CANCELLED);
+    assert.web3Event(res, {
+      event: 'StatusUpdated',
+      args: {
+        connection: conn.address,
+        from: accounts[1],
+        to: accounts[2],
+        oldStatus: PROPOSED,
+        newStatus: CANCELLED
+      },
+    });
   });
 
   it("can be cancelled by acceptor before acceptance", async () => {
     let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
-    await conn.cancel({from: accounts[2]});
+    let res = await conn.cancel({from: accounts[2]});
     assert.equal(await conn.status.call(), CANCELLED);
+    assert.web3Event(res, {
+      event: 'StatusUpdated',
+      args: {
+        connection: conn.address,
+        from: accounts[1],
+        to: accounts[2],
+        oldStatus: PROPOSED,
+        newStatus: CANCELLED
+      },
+    });
   });
 
   it("cannot be cancelled by other accounts before acceptance", async () => {
@@ -49,15 +70,35 @@ contract("SocialConnection", async (accounts) => {
   it("can be cancelled by initator after acceptance", async () => {
     let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
     await conn.accept({from: accounts[2]});
-    await conn.cancel({from: accounts[1]});
+    let res = await conn.cancel({from: accounts[1]});
     assert.equal(await conn.status.call(), CANCELLED);
+    assert.web3Event(res, {
+      event: 'StatusUpdated',
+      args: {
+        connection: conn.address,
+        from: accounts[1],
+        to: accounts[2],
+        oldStatus: ACCEPTED,
+        newStatus: CANCELLED
+      },
+    });
   });
 
   it("can be cancelled by acceptor after acceptance", async () => {
     let conn = await SocialConnection.new(accounts[2], {from: accounts[1]});
     await conn.accept({from: accounts[2]});
-    await conn.cancel({from: accounts[2]});
+    let res = await conn.cancel({from: accounts[2]});
     assert.equal(await conn.status.call(), CANCELLED);
+    assert.web3Event(res, {
+      event: 'StatusUpdated',
+      args: {
+        connection: conn.address,
+        from: accounts[1],
+        to: accounts[2],
+        oldStatus: ACCEPTED,
+        newStatus: CANCELLED
+      },
+    });
   });
 
   it("cannot be cancelled by other accounts after acceptance", async () => {

--- a/social-account/truffle-config.js
+++ b/social-account/truffle-config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // See <http://truffleframework.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+};

--- a/social-account/truffle.js
+++ b/social-account/truffle.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // See <http://truffleframework.com/docs/advanced/configuration>
+  // to customize your Truffle configuration!
+};


### PR DESCRIPTION
I tried to think about scenarios where a correct `SocialAccount`/`SocialConnection` interacts with malicious ones.

Started with the following assumptions:
1. `SocialConnection` represents a kind of commitment between two `SocialAccounts`, therefore it's important that both parties understand what they accept. Moreover, whoever wants to check that `SocialConnection` is accepted, should also check its code.
2. One important property of standard `SocialConnection` is that either party can cancel it at any moment.
3. It's nonetheless handy to have a simple method for proposing/accepting friendship with a particular `SocialAccount`.

The following design decisions followed:

1. If a contract A is to accept connection request from contract B, the exact `SocialConnection` contract should be fixed when creating a transaction. Otherwise, contract B may front-run or provide a different `SocialConnection` to `A.addFriend()` method, which is no good (e.g. that malicious `SocialConnection` may have no `cancel` method). Therefore, `addFriend` method takes `SocialConnection` parameter. Still, there is a simpler unsafer version called `addFriendWithAnyConnection`.
2. Each contract keeps a `mapping` of accepted friendships and outgoing requests. There is no advantage in notifying the other party about outgoing request; the other party shouldn't accept without checking `SocialConnection`'s code first anyway. The worst a malicious contract can do with such list of outgoing requests is to provide "wrong" friendship request or say that there are none, but that cannot be prevented as we don't have a trusted list of all requests.
3. `SocialConnection.cancel()`/`SocialConnection.accept()` should not depend on any calls to `SocialAccount`s, so they can't prevent us from cancelling/accepting a connection (e.g. by throwing exception). As we already check `SocialConnection` when accepting a friendship, we know we're signing up for.
4. As a consequence of the previous two bullets: it's possible for a contract to keep a link to a cancelled `SocialConnection`. So, instead of `selfdestroy`ing a connected after cancellation, I've added a special state - it's much easier to check value in Solidity than "whether an address specifies a non-empty contract".

I feel that testing code is rather cumbersome. Any suggestions on making it neater (e.g. by re-using existing open-source libraries) are highly appreciated.